### PR TITLE
Implementando o método cancelarCompra que faz o cancelamento da compra

### DIFF
--- a/booksCrudService/src/main/java/com/books/crud/booksdCrud/compra/Compra.java
+++ b/booksCrudService/src/main/java/com/books/crud/booksdCrud/compra/Compra.java
@@ -90,6 +90,10 @@ public class Compra {
         this.compraStatus = CompraStatus.ABERTA;
     }
 
+    public CompraStatus pegarCompraStatus() {
+        return this.compraStatus;
+    }
+
     public void aguardarPagamento(){
         this.compraStatus = CompraStatus.AGUARDANDO_PAGAMENTO;
     }

--- a/booksCrudService/src/main/java/com/books/crud/booksdCrud/compra/CompraService.java
+++ b/booksCrudService/src/main/java/com/books/crud/booksdCrud/compra/CompraService.java
@@ -47,4 +47,12 @@ public class CompraService {
         return compraRepository.save(compra);
 
     }
+
+    public void cancelarCompra(Compra compra) {
+        if(compra.pegarCompraStatus() == CompraStatus.CANCELADA || compra.pegarCompraStatus() == CompraStatus.FINALIZADA){
+            throw new IllegalStateException("Não é possivel realizar o cancelamento de compras com status Cancelada ou Finaliada");
+        }
+        compra.cancelarCompra();
+
+    }
 }


### PR DESCRIPTION
O método cancelar compra recebe o objeto e verifica o status dele. 

Se o status for igual a CANCELADA ou FINALIZADA, o sistema emite um erro, pois, seguindo as regras de status, não é possível cancelar uma compra que possui qualquer desses status.
